### PR TITLE
chore: merge upstream sschmitt-cg/Chords main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ dist/
 .vite/
 .DS_Store
 *.local
+*.local.json
 .claude/

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -113,6 +113,13 @@ parity. Open both side by side during testing.
 
 ---
 
+## CI / Tooling (follow-ups from PR #90)
+
+- [ ] Vitest config uses `/// <reference types="vitest" />` triple-slash pattern (older); migrate to `import type { UserConfig } from 'vitest/config'` when upgrading Vitest
+- [ ] `computeRomans` test for non-7-note input tests an undocumented fallback — if the fallback behavior ever changes, this test will give a false signal; revisit when expanding theory test coverage
+
+---
+
 ## Bugs / Polish
 
 - [ ] Enharmonic preference persistence (user picks C# vs Db — survives navigation)


### PR DESCRIPTION
## What

Pulls upstream `sschmitt-cg/Chords` `main` into our `main`. Four upstream commits, two of them substantive:

| Commit | Effect |
|---|---|
| `c357094` docs: add CI/tooling follow-up notes from PR #90 review | Adds a "CI / Tooling (follow-ups from PR #90)" section to `BACKLOG.md` |
| `b00160d` fix: protect `*.local.json` files from accidental commits | Adds `*.local.json` to `.gitignore` |
| `5057b89`, `1f8b820` | Merge commits (PR #91 and #92 upstream) |

## Why

The upstream parent fork has moved forward; this catches us up. The two substantive changes are also responses to a review of our own testing PR (numbered #90 upstream), so it's worth picking them up promptly.

## Conflict resolution

One conflict — `.gitignore`:

- **Upstream** added `*.local.json` between `*.local` and `.claude/`
- **Ours** still has `.claude/` (added/removed/re-added by imonroe across recent commits)
- **Resolution**: kept both lines, in upstream's order. Also fixed a missing trailing newline our version had.

`BACKLOG.md` auto-merged cleanly — upstream added a new section in a region we hadn't touched.

## Heads-up: two backlog items the upstream maintainer flagged

These are now tracked in `BACKLOG.md` as a result of the merge — sharing them here so they don't get lost:

1. **Vitest config uses the older `/// <reference types="vitest" />` triple-slash pattern.** Worth migrating to `import type { UserConfig } from 'vitest/config'` next time we upgrade Vitest. (`vite.config.ts:1`)
2. **`computeRomans` test for non-7-note input tests an undocumented fallback.** If that fallback behavior changes, the test gives a false signal. Revisit when expanding theory test coverage. (`src/theory/__tests__/theory.test.ts`)

Neither is blocking; both are good catches.

## How to test

```bash
npm install
npm run typecheck   # passes
npm run lint        # passes
npm test            # 47/47
```

All gates green on this branch.

## Checklist

- [x] Conflict resolved deliberately (kept both `.claude/` and `*.local.json`)
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm test` passes (47/47)
- [x] No surprise file changes — diff is exactly the two upstream substantive commits + the trivial `.gitignore` newline fix

https://claude.ai/code/session_013ARHAFtVMiaVMCcKwXeVsa

---
_Generated by [Claude Code](https://claude.ai/code/session_013ARHAFtVMiaVMCcKwXeVsa)_